### PR TITLE
access to new control through web on add-on installation

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/4.3.4/versions.cfg
+extends = http://dist.plone.org/release/5.0/versions.cfg
 extensions = mr.developer
 parts =
     instance

--- a/src/experimental/safe_html_transform/browser/configure.zcml
+++ b/src/experimental/safe_html_transform/browser/configure.zcml
@@ -24,7 +24,7 @@
     <include file="permissions.zcml" />
     <!-- Filter Control Panel -->
     <browser:page
-      name="safe_html_transform-settings"
+      name="filter-controlpanel"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       layer="..interfaces.IExperimentalSafeHtmlTransformLayer"
       class=".controlpanel.FilterControlPanel"

--- a/src/experimental/safe_html_transform/profiles/default/controlpanel.xml
+++ b/src/experimental/safe_html_transform/profiles/default/controlpanel.xml
@@ -9,7 +9,7 @@
         appId="experimental.safe_html_transform"
         category="Collective"
         condition_expr=""
-        url_expr="string:${portal_url}/@@safe_html_transform-settings"
+        url_expr="string:${portal_url}/@@filter-controlpanel"
         visible="True"
         i18n:attributes="title">
         <permission>Manage portal</permission>

--- a/src/experimental/safe_html_transform/tests/test_filter.py
+++ b/src/experimental/safe_html_transform/tests/test_filter.py
@@ -51,3 +51,26 @@ class DocumentFunctionalTest(unittest.TestCase):
         self.browser.getControl(name="form.buttons.cancel").click()
         self.assertTrue(
             'Changes canceled.' in self.browser.contents)
+
+    def test_add_new_link(self):
+        self.browser.open('http://nohost/plone/++add++Document')
+        # self.browser.getLink('Add new').click()
+        self.assertTrue(
+            'Add Page' in self.browser.contents)
+
+    def test_add_new_content(self):
+        self.browser.open('http://nohost/plone/++add++Document')
+        # self.browser.getLink('Add new').click()
+        self.assertTrue(
+            'Body Text' in self.browser.contents)
+        self.browser.getControl('Body Text').value = \
+            '<p>Testing that<script> tag and its contents get stripped</script> works.</p>'
+        self.browser.getControl('Title').value = 'LOL'
+        self.browser.getControl('Save').click()
+        self.assertTrue(
+            'Changes saved.' in self.browser.contents)
+        self.assertTrue(
+            'LOL' in self.browser.contents)
+        self.assertTrue(
+            '<p>Testing that<script> tag and its contents get stripped</script> works.</p>' in self.browser.contents
+        )

--- a/src/experimental/safe_html_transform/tests/test_filter.py
+++ b/src/experimental/safe_html_transform/tests/test_filter.py
@@ -24,36 +24,30 @@ class DocumentFunctionalTest(unittest.TestCase):
         )
 
     def test_url_end(self):
-        self.browser.open(self.portal_url + '/@@safe_html_transform-settings')
+        self.browser.open(self.portal_url + '/@@filter-controlpanel')
         self.assertTrue(
-            self.browser.url.endswith('safe_html_transform-settings'))
+            self.browser.url.endswith('filter-controlpanel'))
 
     def test_save_button(self):
-        self.browser.open(self.portal_url + '/@@safe_html_transform-settings')
+        self.browser.open(self.portal_url + '/@@filter-controlpanel')
         self.browser.getControl(name="form.buttons.save").click()
         self.assertTrue(
-            self.browser.url.endswith('safe_html_transform-settings'))
+            self.browser.url.endswith('filter-controlpanel'))
 
     def test_status_msg_after_save(self):
-        self.browser.open(self.portal_url + '/@@safe_html_transform-settings')
+        self.browser.open(self.portal_url + '/@@filter-controlpanel')
         self.browser.getControl(name="form.buttons.save").click()
         self.assertTrue(
             'Changes saved.' in self.browser.contents)
 
     def test_cancel_button(self):
-        self.browser.open(self.portal_url + '/@@safe_html_transform-settings')
+        self.browser.open(self.portal_url + '/@@filter-controlpanel')
         self.browser.getControl(name="form.buttons.cancel").click()
         self.assertTrue(
             self.browser.url.endswith('plone_control_panel'))
 
     def test_status_msg_after_cancel(self):
-        self.browser.open(self.portal_url + '/@@safe_html_transform-settings')
+        self.browser.open(self.portal_url + '/@@filter-controlpanel')
         self.browser.getControl(name="form.buttons.cancel").click()
         self.assertTrue(
             'Changes canceled.' in self.browser.contents)
-
-    def test_add_new_link(self):
-        self.browser.open('http://nohost/plone/portal_factory/Document/document.2015-08-14.9025882105/edit')
-        # self.browser.getLink('Add new').click()
-        self.assertTrue(
-            'Add Page' in self.browser.contents)


### PR DESCRIPTION
Now we can access safe_html control panel through the web by following methods :- 

1) Install the add-on
2) click on the HTML Filtering in site setup
3) There we will get our new control panel instead of old safe_html control panel.

Also if we try to click the HTML Filtering in site setup before installing our add-on we will get the access of old safe_html. 
